### PR TITLE
package.jsonのhomepageはサーバでの階層を示すもののようなので修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/kaminchu/tnkgroup/issues"
   },
-  "homepage": "https://github.com/kaminchu/tnkgroup#readme",
+  "homepage": "/",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
元々の
```
homepage: https://github.com/kaminchu/tnkgroup#readme
```
のうち
```
/kaminchu/tnkgroup
```
が最上位階層として採用され、あご環境ではcssとかの読み込みに失敗しました！
![](http://i.gyazo.com/68e36ba389de2ec4d080da03df2ab23b.png)
